### PR TITLE
Fix To Pull or not to Pull 404

### DIFF
--- a/content/posts/2017-10-17-to-pull-or-not-to-pull.md
+++ b/content/posts/2017-10-17-to-pull-or-not-to-pull.md
@@ -58,7 +58,7 @@ Yet another presentation at the [SagLacIO][saglacio]. What is open source? What 
 <div class="responsive-iframe-wrapper">
     <div class="responsive-iframe">
         <img class="ratio" src="/images/layout/placeholder_16x9.gif" alt="placeholder"/>
-        <iframe src="https://to-pull-or-not-to-pull.gableroux.com/" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+        <iframe src="https://gableroux.github.io/to-pull-or-not-to-pull.gableroux.com/#/" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
     </div>
 </div>
 


### PR DESCRIPTION
J'ai trouvé [ceci](https://github.com/GabLeRoux/to-pull-or-not-to-pull.gableroux.com/issues/9) qui m'a indiqué comment quickfix la page de To Pull or not to Pull.

Testé en local et ça marche A1. BTW nice hugo, ca roule en maudit. Je connaissais pas

Bon hacktoberfest!